### PR TITLE
Support optional createCanvas factory

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -5,5 +5,6 @@ export default {
 	variation: { min: 5, max: 20, enabled: true },
 	shift: { min: 60, max: 300 },
 	figurealpha: { min: .7, max: 1.2 },
-	light:{ top:10, right:-8, left:-4, enabled: true}
+	light:{ top:10, right:-8, left:-4, enabled: true},
+	createCanvas: () => document.createElement('canvas'),
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,7 @@
 import figures from './figures';
 import sprite from './sprite';
 import shapes from './shapes';
-import { chunkHash, createCanvas } from './utils';
+import { initCanvas } from './utils';
 
 
 /**
@@ -32,7 +32,7 @@ function renderer(hashValues, params) {
 
 	// Draw on canvas
 	const size = params.size || 100;
-	const canvas = createCanvas(size);
+	const canvas = initCanvas(size, params.createCanvas());
 	const ctx = canvas.getContext('2d');
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,8 +29,7 @@ const deepMerge = (...objects) => {
 }
 
 
-const createCanvas = size => {
-	const canvas = document.createElement('canvas');
+const initCanvas = (size, canvas) => {
 
 	canvas.style.width = size + "px";
 	canvas.style.height = size + "px";
@@ -46,4 +45,4 @@ const createCanvas = size => {
 	return canvas;
 }
 
-export { deepMerge, chunkHash, createCanvas }
+export { deepMerge, initCanvas }


### PR DESCRIPTION
This adds no additional dependencies and doesn't break anything but instead adds an optional `createCanvas` factory function on the params which a caller can use to inject their own canvas.

I plan to implement a `hashicon-cli` library which will inject the node-canvas in to enable server side image rendering.