### PR TITLE
Update docs and test with actual node-canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ HashIcon's values are extracted from the hash, and controlled with the following
 
 ```js
 {
+
 // size px (HiDPI/Retina aware)
 size: 100,
 
@@ -90,23 +91,30 @@ shift: { min: 60, max: 300 },
 figurealpha: { min: .7, max: 1.2 }, // alpha
 
 // simulate a 3d cube by different areas gets some more/less light applyed 
-light:{ top:10, right:-8, left:-4, enabled: true}
+light:{ top:10, right:-8, left:-4, enabled: true},
+
+// Allows a custom canvas to be used to render into
+createCanvas: (width, height) => HTMLCanvasElement
+
 }
 ```
 
 Node
 ---
-
-> TODO: node-canvas example
-
 Install with: 
-
 ```shell
-$ npm install hashicon
-```   
+$ npm install hashicon canvas
+```
+Run with:
+```js
+import hashicon from 'hashicon'
+import { createCanvas } from 'canvas'
+const icon = hashicon('0xdc53525847b67a9e32d80066202d5744c86ae500', { createCanvas })
+const url = icon.toDataURL()
+console.log(url)
+```
 
 See ESM+CJS builds [here](dist).
-
 
 Development
 -----------

--- a/src/params.js
+++ b/src/params.js
@@ -1,3 +1,6 @@
+
+import { createCanvas } from './utils';
+
 export default {
 	hue: { min: 0, max: 360 },
 	saturation: { min: 70, max: 100 },
@@ -6,5 +9,5 @@ export default {
 	shift: { min: 60, max: 300 },
 	figurealpha: { min: .7, max: 1.2 },
 	light:{ top:10, right:-8, left:-4, enabled: true},
-	createCanvas: () => document.createElement('canvas'),
+	createCanvas,
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,6 @@
 import figures from './figures';
 import sprite from './sprite';
 import shapes from './shapes';
-import { initCanvas } from './utils';
 
 
 /**
@@ -29,10 +28,11 @@ function renderer(hashValues, params) {
 	const shift = processParam(params.shift, hashValues[3]);
 	const figurealpha = processParam(params.figurealpha, hashValues[4]);
 	const figure = hashValues[5] % figures.length;
+	const createCanvas = params.createCanvas;
 
 	// Draw on canvas
 	const size = params.size || 100;
-	const canvas = initCanvas(size, params.createCanvas());
+	const canvas = createCanvas(size, size);
 	const ctx = canvas.getContext('2d');
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,15 +29,17 @@ const deepMerge = (...objects) => {
 }
 
 
-const initCanvas = (size, canvas) => {
+const createCanvas = (width, height) => {
 
-	canvas.style.width = size + "px";
-	canvas.style.height = size + "px";
+	const canvas = document.createElement('canvas');
+
+	canvas.style.width = width + "px";
+	canvas.style.height = height + "px";
 
 	// Hi-DPI / Retina
 	var dpr = window.devicePixelRatio || 1;
-	canvas.width = size * dpr;
-	canvas.height = size * dpr;
+	canvas.width = width * dpr;
+	canvas.height = height * dpr;
 
 	const ctx = canvas.getContext('2d');
 	ctx.scale(dpr, dpr);
@@ -45,4 +47,4 @@ const initCanvas = (size, canvas) => {
 	return canvas;
 }
 
-export { deepMerge, initCanvas }
+export { deepMerge, createCanvas }


### PR DESCRIPTION
This updates the docs as requested and also testing with the actual canvas api it needed a little tweaking to make it work nicely there.

I changed it to accept (w, h) instead of just (size) because the other canvas api needs that and its much nicer to just pass it in the opts as `{ createCanvas }` than to have to wrap it in a lambda every time. Internally it seems to not matter the renderer can easily just call it as `createCanvas(size, size)`. So that seemed like the best way to do it.


Tested with actual running code:
https://github.com/justinmchase/hashicon-cli/blob/master/src/index.ts

If you'd rather own the cli repo also let me know or I'll make it and you can have it at any point if you want, just let me know. But my plan is to just create simple cli such as:
```
> hashicon $hash --out icon.png
```